### PR TITLE
Adds build pipline for serving examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,0 +1,12 @@
+var funnel = require('broccoli-funnel');
+
+var mergeTrees = require('broccoli-merge-trees');
+
+var sourceTree = funnel('src', { destDir: 'src' });
+
+var vendorTree = funnel('vendor', { destDir: 'vendor' });
+
+var examples = funnel('examples');
+
+module.exports =  mergeTrees([vendorTree, examples, sourceTree]);
+

--- a/dist/bar.html
+++ b/dist/bar.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>D3.chart Base Example</title>
+		<script src="../vendor/d3.js"></script>
+    <script src="../vendor/d3.chart.js"></script>
+		<script src="../src/axis.js"></script>
+		<script src="../src/bars.js"></script>
+    <style>
+			.axis text {
+			  font: 10px sans-serif;
+			}
+
+			.axis line,
+			.axis path {
+			  fill: none;
+			  stroke: #000;
+			  shape-rendering: crispEdges;
+			}
+    </style>
+	</head>
+
+	<body>
+		<div id="bar-viz"></div>
+	</body>
+
+	<script>
+		var data = [
+			{
+				name: 'tom',
+				value: 200
+			},
+			{
+				name: 'yehuda',
+				value: 250
+			},
+			{
+				name: 'iamstef',
+				value: 300
+			},
+			{
+				name: 'machty',
+				value: 150
+			},
+			{
+				name: 'rwjblue',
+				value: 378
+			},
+			{
+				name: 'kris',
+				value: 123
+			},
+			{
+				name: 'selvagsz',
+				value: 10
+			}
+		];
+
+		var XAxisChart = d3.select('#bar-viz')
+			.append('svg')
+			.chart('XAxis')
+			.width(600)
+			.height(500);
+
+		XAxisChart.draw(data);
+
+
+		var BarChart = d3.select('#bar-viz')
+			.append('svg')
+			.chart('Bars', {
+				margin: {
+					left: 25,
+					right: 25,
+					top: 50,
+					bottom: 50
+				},
+
+				colors: ['#ccc', '#999', "#aaa", '#dad'],
+
+				rangeRoundBand: 0.05
+			})
+			.width(600)
+			.height(500);
+
+		BarChart.draw(data);
+	</script>
+	</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,5 @@
+<h3> <strong>Welcome to the d3-charts demo</strong> </h3>
+
+<ul>
+  <li><a href="/bar.html">See bar chart example</a></li>
+</ul>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
     "visualization",
     "svg",
     "composable",
-    "reusable"    
-  ]
+    "reusable"
+  ],
+  "devDependencies": {
+    "broccoli": "^0.16.4",
+    "broccoli-funnel": "^0.2.3",
+    "broccoli-merge-trees": "^0.2.2"
+  }
 }


### PR DESCRIPTION
`broccoli serve` now serves the examples.

I'll see if I can include live-reload later.